### PR TITLE
mark dependency packages as automatically installed

### DIFF
--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -94,6 +94,7 @@ upgrade() {
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y xivo-config
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y rabbitmq-server
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y xivo-libdao
+	execute apt-mark auto postgresql-11 xivo-config rabbitmq-server xivo-libdao
 	execute apt-get dist-upgrade -y
 	execute apt-get autoremove -y
 	upgrade_dahdi_linux_modules 4.9


### PR DESCRIPTION
reason: when apt install is used to upgrade one dependency package, it
should not change the dependency status of this package