### PR TITLE
Pull request for WAZO-1190-use-sentinel-mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
   set -u  # fail if variable is undefined
   set -o pipefail  # fail if command before pipe fails
   ```
+* sentinel file should not start with digits

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@
   * prefix scripts with two digits
   * use only `-` in the scripts name, not `_`
   * always keep file extension
+* Shell scripts should have the following options (pure shell script doesn't accept `-o` option):
+
+  ```
+  set -e
+  set -u  # fail if variable is undefined
+  set -o pipefail  # fail if command before pipe fails
+  ```

--- a/debian/wazo-upgrade.postinst
+++ b/debian/wazo-upgrade.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for wazo-upgrade
 #
 # see: dh_installdeb(1)
@@ -32,6 +32,22 @@ case "$1" in
         rm -f /var/lib/wazo-upgrade/xivo_admin_dump.json
         rm -f /var/lib/wazo-upgrade/xivo_service_dump.json
         rm -f /var/lib/wazo-upgrade/xivo_user_dump.json
+
+        if [ -f /var/backups/xivo/wazo_dird_sources.yml ]; then
+            touch /var/lib/wazo-upgrade/dump-dird-sources
+        fi
+
+        if [ -f /var/lib/wazo-upgrade/57-provd-reconfigure-all-devices ]; then
+            touch /var/lib/wazo-upgrade/provd-reconfigure-all-devices
+            rm /var/lib/wazo-upgrade/57-provd-reconfigure-all-devices
+        fi
+
+        previous_version="$2"
+        if [[ -z "${previous_version}" ]]; then
+            touch /var/lib/wazo-upgrade/dump-dird-sources
+            touch /var/lib/wazo-upgrade/remove-nginx-symlinks
+            touch /var/lib/wazo-upgrade/provd-reconfigure-all-devices
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/post-start.d/25-provd-reconfigure-all-devices.py
+++ b/post-start.d/25-provd-reconfigure-all-devices.py
@@ -2,7 +2,6 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import argparse
 import os
 import requests
 import sys
@@ -69,33 +68,14 @@ def reconfigure_all_devices():
 
 
 def main():
-    args = parse_args()
-
-    if not args.force:
-        version_installed = os.getenv('WAZO_VERSION_INSTALLED')
-        if version_installed >= '19.13':
-            sys.exit(0)
-
-    sentinel_file = '/var/lib/wazo-upgrade/57-provd-reconfigure-all-devices'
+    sentinel_file = '/var/lib/wazo-upgrade/provd-reconfigure-all-devices'
     if os.path.exists(sentinel_file):
-        # migration already done
         sys.exit(1)
 
     reconfigure_all_devices()
 
     with open(sentinel_file, 'w'):
         pass
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-f',
-        '--force',
-        action='store_true',
-        help="Do not check the variable WAZO_VERSION_INSTALLED. Default: %(default)s",
-    )
-    return parser.parse_args()
 
 
 if __name__ == '__main__':

--- a/post-stop.d/50-remove-nginx-symlinks.sh
+++ b/post-stop.d/50-remove-nginx-symlinks.sh
@@ -9,4 +9,10 @@ set -o pipefail  # fail if command before pipe fails
 # This symlink is left over, after removing wazo-admin-ui and prevents nginx
 # from loading correctly.
 
+SENTINEL="/var/lib/wazo-upgrade/remove-nginx-symlinks"
+
+[ -e "$SENTINEL" ] && exit 0
+
 rm -f /etc/nginx/locations/https-enabled/wazo-admin-ui
+
+touch $SENTINEL

--- a/post-stop.d/50-remove-nginx-symlinks.sh
+++ b/post-stop.d/50-remove-nginx-symlinks.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
 # This symlink is left over, after removing wazo-admin-ui and prevents nginx
 # from loading correctly.
 

--- a/post-stop.d/50-remove-nginx-symlinks.sh
+++ b/post-stop.d/50-remove-nginx-symlinks.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined

--- a/pre-start.d/05-run-xivo-check-db.sh
+++ b/pre-start.d/05-run-xivo-check-db.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+set -e
+set -u  # fail if variable is undefined
+
 xivo-check-db

--- a/pre-start.d/05-run-xivo-check-db.sh
+++ b/pre-start.d/05-run-xivo-check-db.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined

--- a/pre-start.d/10-run-xivo-update-config.sh
+++ b/pre-start.d/10-run-xivo-update-config.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -u  # fail if variable is undefined
+
 echo "Updating Wazo config"
 
 xivo-create-config

--- a/pre-start.d/10-run-xivo-update-config.sh
+++ b/pre-start.d/10-run-xivo-update-config.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined

--- a/pre-start.d/20-wazo-update-keys.sh
+++ b/pre-start.d/20-wazo-update-keys.sh
@@ -2,6 +2,10 @@
 # Copyright 2018 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
 wait_until_ready(){
     WAIT_TIMEOUT=60
     WAIT_INTERVAL=1

--- a/pre-start.d/20-wazo-update-keys.sh
+++ b/pre-start.d/20-wazo-update-keys.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e

--- a/pre-start.d/30-fix-paths-rights.sh
+++ b/pre-start.d/30-fix-paths-rights.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined

--- a/pre-start.d/30-fix-paths-rights.sh
+++ b/pre-start.d/30-fix-paths-rights.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 xivo-fix-paths-rights

--- a/pre-start.d/31-fix-twisted-reactor.sh
+++ b/pre-start.d/31-fix-twisted-reactor.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined

--- a/pre-start.d/31-fix-twisted-reactor.sh
+++ b/pre-start.d/31-fix-twisted-reactor.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
 twistd >/dev/null

--- a/pre-start.d/40-remove-unused-packages.sh
+++ b/pre-start.d/40-remove-unused-packages.sh
@@ -2,6 +2,10 @@
 # Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
 is_package_installed() {
     [ "$(dpkg-query -W -f '${Status}' "$1" 2>/dev/null)" = 'install ok installed' ]
 }

--- a/pre-stop.d/50-dump-dird-sources.sh
+++ b/pre-stop.d/50-dump-dird-sources.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
-set -u
+set -u  # fail if variable is undefined
 
 OUTPUT_FILE='/var/backups/xivo/wazo_dird_sources.yml'
 

--- a/pre-stop.d/50-dump-dird-sources.sh
+++ b/pre-stop.d/50-dump-dird-sources.sh
@@ -5,11 +5,11 @@
 set -e
 set -u  # fail if variable is undefined
 
-OUTPUT_FILE='/var/backups/xivo/wazo_dird_sources.yml'
+SENTINEL="/var/lib/wazo-upgrade/dump-dird-sources"
 
-if dpkg --compare-versions "${WAZO_VERSION_INSTALLED}" "gt" "19.14"; then
-    exit 0
-fi
+[ -e "$SENTINEL" ] && exit 0
+
+OUTPUT_FILE='/var/backups/xivo/wazo_dird_sources.yml'
 
 if [ -e "${OUTPUT_FILE}" ]; then
     exit 0
@@ -23,3 +23,5 @@ fi
 
 "${CONFGEN}" dird/sources.yml > "${OUTPUT_FILE}"
 echo "wazo-dird configuration for sources dumped to ${OUTPUT_FILE}"
+
+touch $SENTINEL


### PR DESCRIPTION
remove wrong rm file
use sentinel mechanic to run upgrade scripts
add missing copyright and license in scripts
use same options in all shell scripts
debian: remove unused sentinel files
rename VERSION variables
debian: remove unused sentinel files
rename scripts to follow styleguide
README: fix styling issues
purge postgresql-9.6
remove never executed script
remove stretch scripts
rename function xivo to wazo
remove unused upgrade code related to stretch