### PR TITLE
invalidate wazo-confgend pjsip cache

### DIFF
--- a/post-start.d/50-invalidate-wazo-confgend-cache.sh
+++ b/post-start.d/50-invalidate-wazo-confgend-cache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
+wazo-confgen asterisk/pjsip.conf --invalidate
+asterisk -rx 'module reload res_pjsip'


### PR DESCRIPTION
Why:

* Alembic migration scripts of xivo-manage-db may change values in the
database used for pjsip.conf generation
* If wazo-confgend is not notified of those changes, it will continue
using the cached files generated before the upgrade