### PR TITLE
remove xivo-dev-ssh-pubkeys

### DIFF
--- a/pre-start.d/40-remove-unused-packages.sh
+++ b/pre-start.d/40-remove-unused-packages.sh
@@ -20,6 +20,7 @@ is_package_purgeable() {
 
 renamed_packages="xivo-confgend
                   xivo-confgend-client
+                  xivo-dev-ssh-pubkeys
                   xivo-dxtora
                   xivo-dxtorc
                   xivo-amid


### PR DESCRIPTION
this package has been renamed with wazo prefix. If we still want to have
ssh access, we will need to reinstall manually wazo-dev-ssh-pubkeys