### PR TITLE
wazo-upgrade: fix buster apt update

### DIFF
--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -229,6 +229,13 @@ check_wizard_has_been_run() {
 	fi
 }
 
+fix_apt_update_buster() {
+  current_debian_version=$(cat /etc/debian_version)
+  if dpkg --compare-versions "${current_debian_version}" le 10.10; then
+      apt-get update --allow-releaseinfo-change > /dev/null
+  fi
+}
+
 is_wazo_configured() {
     if ! systemctl is-active --quiet wazo-confd; then
 		echo "ERROR: wazo-confd is not running: cannot check if the wizard has been run."
@@ -272,6 +279,7 @@ download_only="${download_only:-"0"}"
 force="${force:-"0"}"
 
 check_wizard_has_been_run
+fix_apt_update_buster
 
 if [ $download_only -eq 0 ]; then
 	upgrading_system


### PR DESCRIPTION
Why:

* When upgrading from a Debian < 10.10, apt update would complain about
the Suite having changed from "stable" to "oldstable".
* See more details at
https://linux.debian.bugs.dist.narkive.com/N7J51AmY/bug-992225-suite-value-change-for-buster-package-list-causes-apt-get-update-failures