### PR TITLE
README: create sentinel by postinst

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@
   set -o pipefail  # fail if command before pipe fails
   ```
 * sentinel file should not start with digits
+* sentinel file should also be created by `debian/wazo-upgrade.postinst`


### PR DESCRIPTION
why: to avoid to run script at first `wazo-upgrade` run on new install

related to:
* https://github.com/wazo-platform/wazo-upgrade/pull/46
* https://github.com/wazo-platform/wazo-upgrade/pull/47