### PR TITLE
reset-unassociated-devices-to-autoprov: dont run on slave

### DIFF
--- a/post-start.d/20-reset-unassociated-devices-to-autoprov.py
+++ b/post-start.d/20-reset-unassociated-devices-to-autoprov.py
@@ -52,15 +52,7 @@ if is_slave(confd_client):
 
 logger.debug('Fetching wrongly configured devices...')
 
-session = requests.Session()
-session.headers = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    'X-Auth-Token': token_data['token'],
-}
-
 devices = provd_client.devices.list()['devices']
-
 lines = confd_client.lines.list(recurse=True)['items']
 
 configured_device_ids = {device['id']


### PR DESCRIPTION
Why:

* Slave instances don't have provd running, causing a Traceback to
appear in wazo-upgrade logs