### PR TITLE
remove unused xivo-libdao

### DIFF
--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
@@ -104,8 +104,7 @@ upgrade() {
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y wazo-platform
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y xivo-config
 	execute apt-get install -o Dpkg::Options::="--force-confnew" -y rabbitmq-server
-	execute apt-get install -o Dpkg::Options::="--force-confnew" -y xivo-libdao
-	execute apt-mark auto postgresql-11 xivo-config rabbitmq-server xivo-libdao
+	execute apt-mark auto postgresql-11 xivo-config rabbitmq-server
 	execute apt-get dist-upgrade -y
 	execute apt-get autoremove -y
 	pre_start


### PR DESCRIPTION
why: xivo-libdao was added to fix installation with xivo-ctid (packaging
issue, I guess). Now everything has been removed