### PR TITLE
WAZO-3008: `upgrade` change exchange to wazo-headers

### DIFF
--- a/etc/wazo-upgrade/config.yml
+++ b/etc/wazo-upgrade/config.yml
@@ -25,9 +25,7 @@ bus:
   password: guest
   host: localhost
   port: 5672
-  exchange_name: xivo
-  exchange_type: topic
-  exchange_durable: True
+  exchange_name: wazo-headers
 
 plugind:
   host: localhost


### PR DESCRIPTION
Only configuration files, since bus is unused in the code