### PR TITLE
debian: add dependency on curl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Architecture: all
 Provides: xivo-upgrade
 Conflicts: xivo-upgrade
 Replaces: xivo-upgrade
-Depends: ${misc:Depends}, rename, python, python3
+Depends: ${misc:Depends}, curl, rename, python, python3
 Description: Wazo upgrade tools
  This package provide Wazo upgrading tools


### PR DESCRIPTION
Why:

* curl is used in real-wazo-upgrade