### PR TITLE
WAZO-2858 migration script for HA sentinels

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Architecture: all
 Provides: xivo-upgrade
 Conflicts: xivo-upgrade
 Replaces: xivo-upgrade
-Depends: ${misc:Depends}, curl, rename, python, python3
+Depends: ${misc:Depends}, curl, rename, python, python3, jq
 Description: Wazo upgrade tools
  This package provide Wazo upgrading tools

--- a/debian/wazo-upgrade.postinst
+++ b/debian/wazo-upgrade.postinst
@@ -56,6 +56,7 @@ case "$1" in
             touch /var/lib/wazo-upgrade/set-mobile-hints
             touch /var/lib/wazo-upgrade/move-admins-to-group
             touch /var/lib/wazo-upgrade/replace-provd-py2-plugins
+            touch /var/lib/wazo-upgrade/install-ha-sentinel
         fi
     ;;
 

--- a/post-start.d/65-install-ha-sentinel.sh
+++ b/post-start.d/65-install-ha-sentinel.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+set -u
+set -o pipefail
+
+HA_CONF=/etc/xivo/ha.conf
+if [ -f "$HA_CONF" ]; then
+    node_type=$(jq -r '.node_type' $HA_CONF)
+    if [ "$node_type" = "slave" ]; then
+        touch /var/lib/wazo/is-secondary
+    elif [ "$node_type" = "master" ]; then
+        touch /var/lib/wazo/is-primary
+    fi
+fi

--- a/post-start.d/65-install-ha-sentinel.sh
+++ b/post-start.d/65-install-ha-sentinel.sh
@@ -7,11 +7,18 @@ set -u
 set -o pipefail
 
 HA_CONF=/etc/xivo/ha.conf
-if [ -f "$HA_CONF" ]; then
+UPGRADE_SENTINEL=/var/lib/wazo-upgrade/install-ha-sentinel
+if [ -f "$UPGRADE_SENTINEL" ]; then
+    exit 0
+elif [ -f "$HA_CONF" ]; then
     node_type=$(jq -r '.node_type' $HA_CONF)
     if [ "$node_type" = "slave" ]; then
+        rm -f /var/lib/wazo/is-primary
         touch /var/lib/wazo/is-secondary
     elif [ "$node_type" = "master" ]; then
+        rm -f /var/lib/wazo/is-secondary
         touch /var/lib/wazo/is-primary
     fi
 fi
+touch "$UPGRADE_SENTINEL"
+

--- a/post-start.d/65-install-ha-sentinel.sh
+++ b/post-start.d/65-install-ha-sentinel.sh
@@ -6,11 +6,12 @@ set -e
 set -u
 set -o pipefail
 
-HA_CONF=/etc/xivo/ha.conf
 UPGRADE_SENTINEL=/var/lib/wazo-upgrade/install-ha-sentinel
-if [ -f "$UPGRADE_SENTINEL" ]; then
-    exit 0
-elif [ -f "$HA_CONF" ]; then
+
+[ -e "${UPGRADE_SENTINEL}" ] && exit 0
+
+HA_CONF=/etc/xivo/ha.conf
+if [ -f "$HA_CONF" ]; then
     node_type=$(jq -r '.node_type' $HA_CONF)
     if [ "$node_type" = "slave" ]; then
         rm -f /var/lib/wazo/is-primary
@@ -20,5 +21,5 @@ elif [ -f "$HA_CONF" ]; then
         touch /var/lib/wazo/is-primary
     fi
 fi
-touch "$UPGRADE_SENTINEL"
 
+touch "$UPGRADE_SENTINEL"


### PR DESCRIPTION
post-start.d script to manually create the sentinel file `/var/lib/wazo/is-primary` / `/var/lib/wazo/is-primary` based on HA mode.

depends-on: https://github.com/wazo-platform/wazo-sysconfd/pull/72