### PR TITLE
pre-start: remove wazo-pg-config-update

### DIFF
--- a/pre-start.d/10-run-wazo-pg-config-update.sh
+++ b/pre-start.d/10-run-wazo-pg-config-update.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
-# SPDX-License-Identifier: GPL-3.0-or-later
-set -e
-set -u  # fail if variable is undefined
-
-echo "Updating PostgreSQL config"
-
-/usr/bin/wazo-pg-config-update


### PR DESCRIPTION
Why:

* Config is applied by drop-in file