### PR TITLE
cleanup

### DIFF
--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -130,18 +130,6 @@ upgrading_system() {
 display_asterisk_notice() {
 	ast_version=$(dpkg-query -W -f '${Version}' asterisk 2>/dev/null)
 	case "$ast_version" in
-		8:15.*)
-			ast_major_version="15"
-			;;
-		8:16.*)
-			ast_major_version="16"
-			;;
-		8:17.*)
-			ast_major_version="17"
-			;;
-		8:18.*)
-			ast_major_version="18"
-			;;
 		8:19.*)
 			ast_major_version="19"
 			;;
@@ -178,102 +166,6 @@ display_asterisk_notice() {
 			instability issues, they have been moved from /usr/lib/asterisk/modules to
 			/tmp. To continue using these modules, you will have to install (or recompile)
 			the Asterisk 20 version of these modules.
-
-		EOF
-		fi
-	elif dpkg --compare-versions "$ast_version" le 8:19; then
-		cat <<-EOF
-
-		Asterisk will be upgraded from version $ast_major_version to 19. You might be impacted if you have:
-
-		* custom Asterisk configuration (other than custom dialplan)
-		* custom application using AMI or ARI
-		* custom Asterisk modules (e.g. codec_g729a.so)
-
-		If you find yourself in one of these cases, you should make sure that
-		your customizations still work with Asterisk 19. Please refer to the
-		Wazo upgrade notes for more information.
-
-		EOF
-
-		custom_modules=$(wazo-asterisk-custom-modules)
-		if [ -n "$custom_modules" ]; then
-			for module in $custom_modules; do
-				mv "/usr/lib/asterisk/modules/$module" /tmp
-			done
-			cat <<-EOF
-			WARNING: custom Asterisk modules detected:
-
-			$custom_modules
-
-			Since these modules will not work with Asterisk 19 and might cause major
-			instability issues, they have been moved from /usr/lib/asterisk/modules to
-			/tmp. To continue using these modules, you will have to install (or recompile)
-			the Asterisk 19 version of these modules.
-
-		EOF
-		fi
-	elif dpkg --compare-versions "$ast_version" le 8:18; then
-		cat <<-EOF
-
-		Asterisk will be upgraded from version $ast_major_version to 18. You might be impacted if you have:
-
-		* custom Asterisk configuration (other than custom dialplan)
-		* custom application using AMI or ARI
-		* custom Asterisk modules (e.g. codec_g729a.so)
-
-		If you find yourself in one of these cases, you should make sure that
-		your customizations still work with Asterisk 18. Please refer to the
-		Wazo upgrade notes for more information.
-
-		EOF
-
-		custom_modules=$(wazo-asterisk-custom-modules)
-		if [ -n "$custom_modules" ]; then
-			for module in $custom_modules; do
-				mv "/usr/lib/asterisk/modules/$module" /tmp
-			done
-			cat <<-EOF
-			WARNING: custom Asterisk modules detected:
-
-			$custom_modules
-
-			Since these modules will not work with Asterisk 18 and might cause major
-			instability issues, they have been moved from /usr/lib/asterisk/modules to
-			/tmp. To continue using these modules, you will have to install (or recompile)
-			the Asterisk 18 version of these modules.
-
-		EOF
-		fi
-	elif dpkg --compare-versions "$ast_version" le 8:16; then
-		cat <<-EOF
-
-		Asterisk will be upgraded from version $ast_major_version to 16. You might be impacted if you have:
-
-		* custom Asterisk configuration (other than custom dialplan)
-		* custom application using AMI or ARI
-		* custom Asterisk modules (e.g. codec_g729a.so)
-
-		If you find yourself in one of these cases, you should make sure that
-		your customizations still work with Asterisk 16. Please refer to the
-		Wazo upgrade notes for more information.
-
-		EOF
-
-		custom_modules=$(wazo-asterisk-custom-modules)
-		if [ -n "$custom_modules" ]; then
-			for module in $custom_modules; do
-				mv "/usr/lib/asterisk/modules/$module" /tmp
-			done
-			cat <<-EOF
-			WARNING: custom Asterisk modules detected:
-
-			$custom_modules
-
-			Since these modules will not work with Asterisk 16 and might cause major
-			instability issues, they have been moved from /usr/lib/asterisk/modules to
-			/tmp. To continue using these modules, you will have to install (or recompile)
-			the Asterisk 16 version of these modules.
 
 		EOF
 		fi

--- a/debian/wazo-upgrade.dirs
+++ b/debian/wazo-upgrade.dirs
@@ -1,5 +1,2 @@
 etc/wazo-upgrade/conf.d
-var/lib/wazo
 var/lib/wazo-upgrade
-usr/lib/wazo-upgrade
-usr/share/wazo-upgrade


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines upgrade behavior and packaging by removing legacy paths and notices.
> 
> - Simplifies `display_asterisk_notice` to only warn/migrate custom modules when upgrading to Asterisk 20; removes branches for versions 16/18/19 and related messaging
> - Cleans `debian/wazo-upgrade.dirs` by dropping unused directories (`var/lib/wazo`, `usr/lib/wazo-upgrade`, `usr/share/wazo-upgrade`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72297e7e156d7701423c45bffda60798999a28ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->