### PR TITLE
ITEM-218-WAZO-4045-confd-timeout-many-users

### DIFF
--- a/post-start.d/20-reset-unassociated-devices-to-autoprov.py
+++ b/post-start.d/20-reset-unassociated-devices-to-autoprov.py
@@ -31,6 +31,22 @@ def _load_key_file(config):
                      'password': key_file['service_key']}}
 
 
+def _paginate(callback, limit=1000, **kwargs):
+    result = callback(limit=limit, offset=0, **kwargs)
+    total = result['total']
+    items = result['items']
+    offset = len(items)
+    while offset < total:
+        new_items = callback(limit=limit, offset=offset, **kwargs)['items']
+        if not new_items:
+            break
+        items.extend(new_items)
+        offset += len(new_items)
+    if len(items) != total:
+        logger.warning('Expected %s lines, got %s', total, len(items))
+    return items
+
+
 def is_slave(confd_client):
     ha_config = confd_client.ha.get()
     return ha_config['node_type'] == 'slave'
@@ -53,7 +69,7 @@ if is_slave(confd_client):
 logger.debug('Fetching wrongly configured devices...')
 
 devices = provd_client.devices.list()['devices']
-lines = confd_client.lines.list(recurse=True)['items']
+lines = _paginate(confd_client.lines.list, recurse=True)
 
 configured_device_ids = {device['id']
                          for device in devices


### PR DESCRIPTION
Fetching all lines in a single request causes a timeout on systems
with a large number of users. Paginate in batches of 1000 instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate operational risk: changes how `confd_client.lines.list` data is fetched in a post-start script, which could affect which devices get reset if pagination/`total` metadata is inconsistent.
> 
> **Overview**
> Prevents timeouts when this post-start script inspects many users by replacing the single `confd_client.lines.list(recurse=True)` call with a new `_paginate()` helper that fetches results in batches (default 1000) using `limit`/`offset`.
> 
> Adds a warning if the accumulated item count does not match the API-reported `total`, but otherwise keeps the device reset-to-autoprov behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc7de98612ba558895fcc9e273de8eb8fac1db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->