### PR TITLE
pre-start: ensure deletable=false for provisioning default configurations

### DIFF
--- a/pre-start.d/30-fix-provd-deletable-configs.sh
+++ b/pre-start.d/30-fix-provd-deletable-configs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+set -u
+set -o pipefail
+
+CONFIGS_DIR=/var/lib/wazo-provd/jsondb/configs
+
+# Configs created by the wazo-confd wizard that must remain non-deletable.
+WIZARD_CONFIGS="base default defaultconfigdevice autoprov"
+
+if [ -d "${CONFIGS_DIR}" ]; then
+    for config_id in ${WIZARD_CONFIGS}; do
+        config_file="${CONFIGS_DIR}/${config_id}"
+        [ -f "${config_file}" ] || continue
+        if [ "$(jq -r '.deletable' "${config_file}")" != "false" ]; then
+            echo "Restoring deletable=false on ${config_file}"
+            tmp_file="$(mktemp --tmpdir="${CONFIGS_DIR}" ".${config_id}.XXXXXX")"
+            jq -c '.deletable = false' "${config_file}" > "${tmp_file}"
+            chown --reference="${config_file}" "${tmp_file}"
+            chmod --reference="${config_file}" "${tmp_file}"
+            mv "${tmp_file}" "${config_file}"
+        fi
+    done
+fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Startup-only data repair on a fixed set of provisioning config files; no auth or API surface changes.
> 
> **Overview**
> Adds a **pre-start** hook that runs before the service comes up and **re-enforces** `deletable: false` on four wizard-owned provisioning configs in `/var/lib/wazo-provd/jsondb/configs` (`base`, `default`, `defaultconfigdevice`, `autoprov`).
> 
> If any of those JSON files exist and `deletable` is not already `false`, the script rewrites the field with `jq` via a temp file in the same directory, then restores owner/mode from the original before replacing the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bd6b3df5ccfe1e31d345f543cd1aaede929c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->