### PR TITLE
ITEM-469 Abort upgrade when database migrations are disabled

### DIFF
--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -180,6 +180,24 @@ wazo_version_candidate() {
 	echo "$(LANG='C' apt-cache policy $APT_OPTIONS wazo-platform | grep Candidate | grep -oE '[0-9]{2}\.[0-9]+(\.[0-9]+)?' | head -n1)"
 }
 
+check_database_migration_is_enabled() {
+	for package in xivo-manage-db wazo-auth; do
+		db_skip=$(debconf-show "$package" 2>/dev/null | grep "$package/db-skip:" | awk '{print $NF}')
+		if [ "$db_skip" = 'true' ]; then
+			cat <<-EOF
+			ERROR: database migrations are disabled ($package/db-skip is "true").
+
+			To re-enable them, run:
+
+			    echo "$package $package/db-skip boolean false" | debconf-set-selections
+
+			then run wazo-upgrade again.
+			EOF
+			exit 1
+		fi
+	done
+}
+
 check_wizard_has_been_run() {
 
 	if ! is_wazo_configured; then
@@ -230,6 +248,7 @@ done
 download_only="${download_only:-"0"}"
 force="${force:-"0"}"
 
+check_database_migration_is_enabled
 check_wizard_has_been_run
 
 if [ $download_only -eq 0 ]; then


### PR DESCRIPTION
## Why

An interrupted ansible/ISO installation can leave `xivo-manage-db/db-skip` or `wazo-auth/db-skip` at `true` in debconf. From that point on, every package upgrade silently skips database migrations (`xivo-update-db` / `wazo-auth-upgrade-db`) until a release ships a migration and services break on an outdated schema — the classic "DB error during an upgrade" support case.

## What

Add a pre-check to `real-wazo-upgrade` that aborts with fix instructions when either flag is `true`. It runs before the wizard check, since a system broken by this issue may have wazo-confd down, and the wizard error would mask the real cause. `-f` does not bypass the check: `db-skip=true` on an engine is always a bug, and the fix command shown is the escape hatch.

`wazo-auth/bootstrap-skip` is deliberately not checked — it only matters on fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive guard in the upgrade entry script; no change to migration or package logic beyond failing fast with clearer errors.
> 
> **Overview**
> **`real-wazo-upgrade` now refuses to run** when debconf has `xivo-manage-db/db-skip` or `wazo-auth/db-skip` set to `true`, printing how to clear the flag with `debconf-set-selections` before retrying.
> 
> The new **`check_database_migration_is_enabled`** runs **before** the wizard/`wazo-confd` check so a down confd does not hide the migration-disable root cause. **`-f` does not skip** this guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7345894edc570c71de1f54674f3f84a79fbd1e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->