### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/debian/wazo-upgrade.postinst
+++ b/debian/wazo-upgrade.postinst
@@ -19,7 +19,7 @@ case "$1" in
         if [[ -z "${previous_version}" ]]; then
             # Create sentinel file to avoid running script on new install
             # touch /var/lib/wazo-upgrade/sentinel-file
-            :
+            touch /var/lib/wazo-upgrade/rename-rest-api-max-threads
         fi
     ;;
 

--- a/pre-start.d/50-preserve-fixed-thread-pool.sh
+++ b/pre-start.d/50-preserve-fixed-thread-pool.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+set -u  # fail if variable is undefined
+set -o pipefail  # fail if command before pipe fails
+
+SENTINEL="/var/lib/wazo-upgrade/rename-rest-api-max-threads"
+[ -f "$SENTINEL" ] && exit 0
+
+# rest_api.max_threads changed meaning: it used to be a fixed thread count
+# and is now the ceiling of a demand-scaled pool. Rename custom max_threads
+# to min_threads so tuned systems keep the same number of always-ready
+# threads; the pool may additionally grow up to the new max_threads default.
+
+SERVICES="wazo-agentd wazo-amid wazo-auth wazo-calld wazo-call-logd \
+wazo-chatd wazo-confd wazo-dird wazo-phoned wazo-webhookd"
+
+for service in $SERVICES; do
+    conf_dir="/etc/${service}/conf.d"
+    [ -d "$conf_dir" ] || continue
+    for config_file in "$conf_dir"/*.yml; do
+        [ -f "$config_file" ] || continue
+        grep -qE '^ *max_threads:' "$config_file" || continue
+        echo "Renaming max_threads to min_threads in ${config_file}"
+        sed -i 's/^\( *\)max_threads:/\1min_threads:/' "$config_file"
+    done
+done
+
+touch "$SENTINEL"


### PR DESCRIPTION
Why: rest_api.max_threads changed meaning from fixed thread count to
ceiling of a demand-scaled pool. Renaming keeps the tuned value as the
number of always-ready threads; the pool may additionally grow up to
the new max_threads default. Guarded by a sentinel file so post-26.08
max_threads customizations are never touched; fresh installs get the
sentinel from postinst.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk operational migration: it only renames YAML keys in conf.d when the sentinel is absent, with no auth or data-path changes.
> 
> **Overview**
> **Upgrades** that customized `rest_api.max_threads` get a one-time config rewrite before services start: any `max_threads` key in `/etc/<service>/conf.d/*.yml` is renamed to `min_threads` so the old tuned value still means “always-ready” threads after `max_threads` becomes the ceiling of a demand-scaled pool.
> 
> The migration runs from a new **`pre-start.d/50-preserve-fixed-thread-pool.sh`** hook and is **guarded** by `/var/lib/wazo-upgrade/rename-rest-api-max-threads` (touch at end of script). **Fresh installs** create that sentinel in **`debian/wazo-upgrade.postinst`** instead of the no-op `:` placeholder, so post-26.08 `max_threads` customizations are never touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90a08a3ba439384b6ee4afc647934946fb3c6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->