### PR TITLE
ITEM-531 fail-fast-upgrade-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Consequences for script authors:
   * use only `-` in the scripts name, not `_`
   * always keep file extension
 * Shell scripts should have the following options (pure shell script
-  doesn't accept `-o` option):
+  (`#!/bin/sh`) doesn't accept `-o` option):
 
   ```shell
   set -e

--- a/README.md
+++ b/README.md
@@ -2,23 +2,66 @@
 
 ## Branches
 
-* branch `master`: builds package for Wazo current (distribution wazo-dev-bookworm/pelican-bookworm)
+* branch `master`: builds package for Wazo current (distribution
+  wazo-dev-bookworm/pelican-bookworm)
 
 ## Upgrade scripts
 
-* `pre-stop` and `post-stop` scripts must be compatible with the previous Debian version: they will
-  be run at the beginning of `wazo-dist-upgrade`.
+* `pre-stop` and `post-stop` scripts must be compatible with the previous
+  Debian version: they will be run at the beginning of `wazo-dist-upgrade`.
+
+### Failure handling
+
+A script exiting with a non-zero status aborts the upgrade, except in the
+`post-start` phase:
+
+* `pre-stop`: the upgrade is aborted (nothing has changed yet).
+* `post-stop`: the upgrade is aborted and Wazo services are restarted
+  (packages are not upgraded yet).
+* `pre-start`: Wazo services are restarted, then the upgrade is aborted and
+  reported as partially upgraded. A stopped Wazo is a worse outage than a
+  partially upgraded one, which usually keeps taking calls.
+* `post-start`: all scripts are executed, then the list of failed scripts
+  is printed as a warning. The upgrade is not aborted: the system is
+  already upgraded and services are running.
+
+An aborted upgrade makes `wazo-upgrade` exit with a non-zero status. Services
+that fail to start abort it too.
+
+A marker file (`/var/lib/wazo-upgrade/upgrade-incomplete`) exists from the
+beginning of an upgrade until the services are successfully started. While it
+exists, `wazo-upgrade` warns about the incomplete upgrade at startup and skips
+the wizard check. Services are restarted before aborting, but a failed start
+or an interrupted upgrade leaves Wazo stopped, and that check exits when
+`wazo-confd` is not running, which would block the retry.
+
+Consequences for script authors:
+
+* Scripts must be re-entrant: the recovery path after a failure is to fix
+  the issue and re-execute `wazo-upgrade`, which runs all scripts of all
+  phases again. Use a sentinel file (see below) or make the script
+  naturally idempotent.
+* Best-effort scripts (cleanups, optional steps) must handle their own
+  errors internally (e.g. `|| echo "WARNING: ..."`) with a comment
+  explaining why the failure is tolerated — the runner treats any non-zero
+  exit as fatal, apart from `post-start`.
+* `post-start` scripts run against a live system: failures that are routine
+  (an unreachable phone, an offline plugin repository) must be logged and
+  contained per item rather than propagated.
 * Naming conventions:
   * prefix scripts with two digits
   * use only `-` in the scripts name, not `_`
   * always keep file extension
-* Shell scripts should have the following options (pure shell script doesn't accept `-o` option):
+* Shell scripts should have the following options (pure shell script
+  doesn't accept `-o` option):
 
-  ```
+  ```shell
   set -e
   set -u  # fail if variable is undefined
   set -o pipefail  # fail if command before pipe fails
   ```
-* each script should check for sentinel file before running and create one at the end.
+
+* each script should check for sentinel file before running and create one
+  at the end.
 * sentinel files should not start with digits
 * sentinel files should also be created by `debian/wazo-upgrade.postinst`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ A script exiting with a non-zero status aborts the upgrade, except in the
   already upgraded and services are running.
 
 An aborted upgrade makes `wazo-upgrade` exit with a non-zero status. Services
-that fail to start abort it too.
+that fail to start abort it too. The exit status tells which phase failed:
+
+| failure | exit status |
+|---------|-------------|
+| `pre-stop` script, or any other fatal error | 1 |
+| `post-stop` script | 2 |
+| `pre-start` script | 3 |
+| `post-start` script (upgrade completed, not aborted) | 4 |
 
 A marker file (`/var/lib/wazo-upgrade/upgrade-incomplete`) exists from the
 beginning of an upgrade until the services are successfully started. While it

--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -111,8 +111,10 @@ stop_wazo() {
 }
 
 start_wazo() {
-	wazo-service enable
-	wazo-service restart
+	local status=0
+	wazo-service enable || status=$?
+	wazo-service restart || status=$?
+	return $status
 }
 
 upgrade() {

--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Copyright 2011-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 lib_directory="/usr/share/wazo-upgrade"
+upgrade_incomplete_file="/var/lib/wazo-upgrade/upgrade-incomplete"
 : ${WAZO_CONFD_PORT:='9486'}
 
 APT_OPTIONS='-o DPkg::Lock::Timeout=15'
@@ -26,38 +27,61 @@ is_package_installed() {
 	[ "$(dpkg-query -W -f '${Status}' "$1" 2>/dev/null)" = 'install ok installed' ]
 }
 
-differed_action() {
+# Sets $failed_script and returns non-zero on the first script failure
+run_upgrade_scripts() {
 	local state=$1
+	failed_script=''
 	shopt -qs nullglob  # avoid failing when action directory has no scripts
 	for script in "$lib_directory/$state.d"/*; do
 		echo "Executing upgrade script $script..."
-		$script
-	done
-	shopt -qu nullglob
-}
-
-pre_stop() {
-	shopt -qs nullglob  # avoid failing when pre-stop directory has no scripts
-	for script in "$lib_directory/pre-stop.d"/*; do
-		echo "Executing upgrade script $script..."
-		$script
-		if [ $? -ne 0 ]; then
-			fatal_error "Failed to execute $script\nPlease, fix this issue before re-executing wazo-upgrade"
+		if ! $script; then
+			failed_script=$script
+			break
 		fi
 	done
 	shopt -qu nullglob
+	[ -z "$failed_script" ]
+}
+
+pre_stop() {
+	if ! run_upgrade_scripts pre-stop; then
+		fatal_error "Failed to execute $failed_script\nPlease, fix this issue before re-executing wazo-upgrade"
+	fi
 }
 
 post_stop() {
-	differed_action post-stop
+	if ! run_upgrade_scripts post-stop; then
+		start_wazo
+		fatal_error "Failed to execute $failed_script\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade"
+	fi
 }
 
+# A stopped Wazo is a worse outage than a partially upgraded one
 pre_start() {
-	differed_action pre-start
+	if ! run_upgrade_scripts pre-start; then
+		start_wazo
+		fatal_error "Failed to execute $failed_script\nThe system is only partially upgraded.\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade"
+	fi
 }
 
+# The system is already upgraded and running: report failures without aborting
 post_start() {
-	differed_action post-start
+	local failed_scripts=''
+	shopt -qs nullglob  # avoid failing when post-start directory has no scripts
+	for script in "$lib_directory/post-start.d"/*; do
+		echo "Executing upgrade script $script..."
+		if ! $script; then
+			failed_scripts="$failed_scripts $script"
+		fi
+	done
+	shopt -qu nullglob
+	if [ -n "$failed_scripts" ]; then
+		echo "****************** WARNING ************************"
+		echo -e "Failed to execute the following scripts:$failed_scripts"
+		echo "The system has been upgraded and Wazo services are running."
+		echo "Please check /var/log/wazo-upgrade.log for details."
+		echo "****************** WARNING ************************"
+	fi
 }
 
 execute() {
@@ -88,6 +112,7 @@ upgrade() {
 	export WAZO_VERSION_CANDIDATE=$(wazo_version_candidate)
 	export XIVO_VERSION_INSTALLED=$WAZO_VERSION_INSTALLED
 	export XIVO_VERSION_CANDIDATE=$WAZO_VERSION_CANDIDATE
+	touch "$upgrade_incomplete_file"
 	pre_stop
 	stop_wazo
 	post_stop
@@ -99,10 +124,14 @@ upgrade() {
 	execute apt-mark auto $APT_OPTIONS postgresql-15 xivo-config rabbitmq-server
 	execute apt-get dist-upgrade $APT_OPTIONS -y
 	execute apt-get autoremove $APT_OPTIONS -y
-	pre_start
-	start_wazo
-	post_start
 	wazo-check-conffiles
+	pre_start
+	# The marker file is kept while Wazo is down to allow a retry
+	if ! start_wazo; then
+		fatal_error "Wazo services failed to start\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade"
+	fi
+	rm -f "$upgrade_incomplete_file"
+	post_start
 }
 
 display_wazo_version() {
@@ -114,8 +143,20 @@ debian_version_installed() {
 	cut -d. -f1 /etc/debian_version
 }
 
+display_previous_upgrade_notice() {
+	if [ "$resuming_failed_upgrade" -eq 1 ]; then
+		cat <<-EOF
+
+		WARNING: the previous upgrade did not complete. Upgrade scripts will be
+		re-executed during this upgrade.
+
+		EOF
+	fi
+}
+
 upgrading_system() {
 	display_wazo_version
+	display_previous_upgrade_notice
 	display_asterisk_notice
 	if [ $force -eq 0 ]; then
 		read -p 'Would you like to upgrade your system (all services will be restarted) [Y/n]? ' answer
@@ -199,6 +240,8 @@ check_database_migration_is_enabled() {
 }
 
 check_wizard_has_been_run() {
+	# The check cannot run with Wazo stopped, and the wizard was run before
+	[ "$resuming_failed_upgrade" -eq 1 ] && return
 
 	if ! is_wazo_configured; then
   		echo "ERROR: You must configure Wazo by running the wizard (POST /api/confd/1.1/wizard) before using wazo-upgrade"
@@ -247,6 +290,10 @@ do
 done
 download_only="${download_only:-"0"}"
 force="${force:-"0"}"
+
+# Set before the current upgrade re-creates the marker file
+resuming_failed_upgrade=0
+[ -f "$upgrade_incomplete_file" ] && resuming_failed_upgrade=1
 
 check_database_migration_is_enabled
 check_wizard_has_been_run

--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -13,14 +13,17 @@ APT_OPTIONS='-o DPkg::Lock::Timeout=15'
 export DEBIAN_FRONTEND=noninteractive
 export APT_LISTCHANGES_FRONTEND=none
 
+# Exit statuses: 1 pre-stop or any other fatal error, 2 post-stop,
+# 3 pre-start, 4 post-start (non-aborting)
 fatal_error() {
 	message=$1
+	exit_status=${2:-1}
 	echo "******************* ERROR *************************"
 	echo "An error occurred during the upgrade."
 	echo "Please check /var/log/wazo-upgrade.log for details."
 	[ -n "$message" ] && echo -e "Error: $message"
 	echo "******************* ERROR *************************"
-	exit -1
+	exit "$exit_status"
 }
 
 is_package_installed() {
@@ -45,14 +48,14 @@ run_upgrade_scripts() {
 
 pre_stop() {
 	if ! run_upgrade_scripts pre-stop; then
-		fatal_error "Failed to execute $failed_script\nPlease, fix this issue before re-executing wazo-upgrade"
+		fatal_error "Failed to execute $failed_script\nPlease, fix this issue before re-executing wazo-upgrade" 1
 	fi
 }
 
 post_stop() {
 	if ! run_upgrade_scripts post-stop; then
 		start_wazo
-		fatal_error "Failed to execute $failed_script\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade"
+		fatal_error "Failed to execute $failed_script\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade" 2
 	fi
 }
 
@@ -60,7 +63,7 @@ post_stop() {
 pre_start() {
 	if ! run_upgrade_scripts pre-start; then
 		start_wazo
-		fatal_error "Failed to execute $failed_script\nThe system is only partially upgraded.\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade"
+		fatal_error "Failed to execute $failed_script\nThe system is only partially upgraded.\nPlease, fix this issue then re-execute wazo-upgrade to complete the upgrade" 3
 	fi
 }
 
@@ -85,6 +88,7 @@ post_start() {
 		echo "The system has been upgraded and Wazo services are running."
 		echo "Please check /var/log/wazo-upgrade.log for details."
 		echo "****************** WARNING ************************"
+		exit 4
 	fi
 }
 
@@ -288,7 +292,7 @@ do
 		'?')
 			echo "${0} : option ${OPTARG} is not valid" >&2
 			usage
-			exit -1
+			exit 1
 		;;
 	esac
 done

--- a/bin/real-wazo-upgrade
+++ b/bin/real-wazo-upgrade
@@ -67,10 +67,14 @@ pre_start() {
 # The system is already upgraded and running: report failures without aborting
 post_start() {
 	local failed_scripts=''
+	local status
 	shopt -qs nullglob  # avoid failing when post-start directory has no scripts
 	for script in "$lib_directory/post-start.d"/*; do
 		echo "Executing upgrade script $script..."
-		if ! $script; then
+		$script
+		status=$?
+		if [ $status -ne 0 ]; then
+			echo -e "\t**Error** running $script: non-zero exit status $status"
 			failed_scripts="$failed_scripts $script"
 		fi
 	done

--- a/bin/wazo-upgrade
+++ b/bin/wazo-upgrade
@@ -64,9 +64,15 @@ append_log_end()
 
 log_and_upgrade()
 {
+    local status
+
     append_log_start $LOGFILE
+    set -o pipefail  # report the upgrade status, not the one of tee
     run_upgrade "$@" |& tee -a $LOGFILE
+    status=$?
+    set +o pipefail
     append_log_end $LOGFILE
+    return $status
 }
 
 log_and_upgrade "$@"

--- a/post-start.d/10-upgrade-official-plugins.py
+++ b/post-start.d/10-upgrade-official-plugins.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+
+import requests
 import urllib3
 
 from wazo_auth_client import Client as AuthClient
@@ -47,10 +49,14 @@ def main():
         for version in plugin['versions']:
             if version['upgradable'] is True:
                 logger.info('Upgrading plugin %s ...', plugin['name'])
-                plugind_client.plugins.install(method='market',
-                                               options={'namespace': 'official',
-                                                        'name': plugin['name'],
-                                                        'version': version['version']})
+                try:
+                    plugind_client.plugins.install(method='market',
+                                                   options={'namespace': 'official',
+                                                            'name': plugin['name'],
+                                                            'version': version['version']})
+                except requests.RequestException as e:
+                    # wazo-plugind installs asynchronously: only the request is checked
+                    logger.error('Failed to upgrade plugin %s: %s', plugin['name'], e)
                 break
 
 

--- a/post-start.d/20-reset-unassociated-devices-to-autoprov.py
+++ b/post-start.d/20-reset-unassociated-devices-to-autoprov.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+
 import requests
 
 from wazo_auth_client import Client as AuthClient
@@ -85,9 +86,9 @@ for device_id in wrongly_configured_device_ids:
     logger.info('Resetting device {}'.format(device_id))
     try:
         confd_client.devices.autoprov(device_id)
-    except requests.HTTPError as e:
-        logger.error(e)
-
-    confd_client.devices.synchronize(device_id)
+        confd_client.devices.synchronize(device_id)
+    except requests.RequestException as e:
+        # an unreachable phone must not prevent resetting the others
+        logger.error('Failed to reset device %s: %s', device_id, e)
 
 logger.debug('Done.')

--- a/pre-start.d/20-wazo-update-keys.sh
+++ b/pre-start.d/20-wazo-update-keys.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 set -u  # fail if variable is undefined
 set -o pipefail  # fail if command before pipe fails
 
+# || true: a failing trap command would override the script exit status
+trap 'systemctl stop wazo-auth || true' EXIT
+
 systemctl restart wazo-auth
 wazo-auth-keys service update
 wazo-auth-keys service clean --users
-systemctl stop wazo-auth

--- a/pre-start.d/40-remove-unused-packages.sh
+++ b/pre-start.d/40-remove-unused-packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
@@ -24,14 +24,17 @@ removed_packages="xivo-swagger-doc"
 
 for package in $renamed_packages $removed_packages; do
     if is_package_purgeable $package; then
-        apt-get purge -y $package
+        # best-effort cleanup: a failed purge must not abort the upgrade
+        apt-get purge -y $package || echo "WARNING: could not purge $package"
     fi
 done
 
 # purge postgresql-XX packages
 if is_package_installed wazo-dbms; then
     if is_package_purgeable postgresql-13; then
-        apt-get purge -y postgresql-13 postgresql-client-13 postgresql-contrib-13
+        # The purge is not atomic: the restart must not depend on its success
+        apt-get purge -y postgresql-13 postgresql-client-13 postgresql-contrib-13 \
+            || echo "WARNING: could not purge all postgresql-13 packages"
         systemctl restart postgresql.service
     fi
 fi


### PR DESCRIPTION
Upgrade script failures were silently ignored in `post-stop`, `pre-start` and
`post-start`: only the runner discarded their exit code, while all in-tree
scripts already use `set -e`. A failed migration went unnoticed and the
upgrade was reported as successful.

## Failure handling per phase

| phase | on failure |
| --- | --- |
| `pre-stop` | abort — nothing has changed yet |
| `post-stop` | restart services, then abort — packages are untouched |
| `pre-start` | restart services, then abort and report the system as partially upgraded |
| `post-start` | run every script, then warn with the list of failed ones — no abort, the system is already upgraded and running |

Services that fail to start abort the upgrade too, before `post-start`, whose
scripts would only fail against a dead system.

The recovery path is to fix the issue and re-execute `wazo-upgrade`, which
re-runs all scripts of all phases (they are re-entrant, guarded by sentinel
files where needed).

### Why services are restarted rather than left stopped

A stopped Wazo is a worse outage than a partially upgraded one: no calls at
all, including emergency calls, and every phone unregistered. A partially
upgraded stack usually keeps taking calls. Support has to be involved either
way, so the choice is between "broken and reachable" and "broken and
unreachable".

The scripts in `pre-start.d` are config, key and package fixups
(`xivo-check-db`, `xivo-update-config`, `wazo-auth-keys`, a provd JSON flag, a
package purge, a config-key rename). A half-finished one leaves the system in
a weird state, not a corrupt one — the schema migrations run in the dpkg
maintainer scripts, during `apt`.

If a future `pre-start` script really must prevent startup (a destructive
in-place data transformation), that should be an explicit signal from the
script itself rather than a blanket policy here.

## Marker file

`/var/lib/wazo-upgrade/upgrade-incomplete` exists from the beginning of an
upgrade until the services are successfully started. While it exists,
`wazo-upgrade` warns about the incomplete upgrade at startup and skips the
wizard check.

Services are restarted before aborting, but a failed start or an interrupted
upgrade leaves Wazo stopped, and the wizard check exits when `wazo-confd` is
not running — without skipping it, the documented recovery path would be
unusable.

## Exit status

The `wazo-upgrade` wrapper reported the status of the `tee` it pipes into,
which is always 0. It now reports the status of the upgrade itself, so an
aborted upgrade no longer looks successful to a caller.

## Upgrade scripts

* `20-wazo-update-keys.sh`: `wazo-auth` is stopped from an `EXIT` trap so it is
  not left running alone on a half-upgraded system. The trap ignores its own
  failure, which would otherwise override the exit status of the script.
* `40-remove-unused-packages.sh`: purges are best-effort, but the PostgreSQL
  restart no longer depends on the purge succeeding — the purge is not atomic
  and can drop the cluster then fail, and a database that does not come back
  must abort.
* `10-upgrade-official-plugins.py` / `20-reset-unassociated-devices-to-autoprov.py`:
  per-item failures are contained instead of aborting the loop. They do not
  fail the script: an unreachable phone is routine, and `wazo-plugind`
  installs asynchronously so the exit code of the request says nothing about
  the result.

## Side effects

* Custom scripts dropped in `pre-stop.d`, `post-stop.d` or `pre-start.d` that
  exit non-zero now fail the upgrade. Best-effort scripts must handle their own
  errors internally.
* Automation calling `wazo-upgrade` now sees a non-zero exit status when the
  upgrade aborts.
* The runner ships with the old package, so this takes effect on the upgrade
  *following* the one that installs it.

## Not covered

`wazo-dist-upgrade` runs the same scripts from the same directories and still
ignores their exit code in all four phases (tracked separately, low priority).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core upgrade orchestration (service stop/start, apt flow, exit codes) and PostgreSQL purge/restart behavior; mis-handled custom scripts in pre/post-stop or pre-start could now block upgrades that previously appeared successful.
> 
> **Overview**
> **Upgrade script failures are no longer ignored** outside `post-start`: `real-wazo-upgrade` runs phase scripts through a shared runner that aborts on the first non-zero exit, with **phase-specific recovery** (restart services on `post-stop`/`pre-start` failures) and **distinct exit codes** (1–4) instead of always exiting `-1`.
> 
> **`post-start` runs all scripts** and only warns (exit 4) if some failed—the upgrade is already done. **`wazo-upgrade`** now propagates the real upgrade exit status via `pipefail`, not `tee`’s 0.
> 
> An **`upgrade-incomplete` marker** is touched at upgrade start and removed only after services start successfully; retries show a warning and **skip the wizard check** when Wazo may still be down. Failed service start aborts before `post-start`; **`wazo-check-conffiles`** moves to before `pre-start`.
> 
> In-tree scripts are adjusted for the stricter runner: **`20-wazo-update-keys.sh`** stops `wazo-auth` on EXIT; **`40-remove-unused-packages.sh`** treats purges as best-effort; post-start Python scripts **log per-item network failures** without failing the whole script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf07171e144eca7b393873f0377c2b85b0f6d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->