### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-upgrade/config.yml
+++ b/etc/wazo-upgrade/config.yml
@@ -16,8 +16,7 @@ amid:
 
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 
 bus:


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* The post-start scripts are the only consumers, and they run after
  `wazo-service start`, when nginx is up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong deploy order breaks internal token requests for upgrade post-start scripts; scope is limited to localhost auth routing config.
> 
> **Overview**
> **Internal wazo-auth calls from `wazo-upgrade` now go through nginx** instead of the wazo-auth daemon port.
> 
> In `etc/wazo-upgrade/config.yml`, `auth.port` changes from **9497** to **80**, and the **`prefix: null`** entry is removed so `wazo-auth-client` uses its default **`/api/auth`** path on the internal nginx entry point.
> 
> Post-start upgrade scripts that build `AuthClient` from this config are the consumers; they assume nginx and the auth location are already in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b81f1ab2dd6761159da92eb690b538df946c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->